### PR TITLE
Changed the display format for the force rank

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -85,14 +85,13 @@ def update_twitter_data():
 
             if rank_int > 1:
 
-                rank = category
                 tweet_id = status.id_str
                 date_created = status.created_at
                 user_name = status.user.screen_name
                 user_location = status.user.location
                 twitter_text = status.full_text
                 source = status.user.url
-                category = category
+                category = rank_int
                 city = None
                 state = None
                 lat = None


### PR DESCRIPTION
Naming: feature/descriptive-name

Reviewers: minimum 2 (Chris and/or 2 from Web or DS respectively and not person who submitted PR)

Description: 
  What is the motivation for changes?
Rank was showing as "Rank 5: 98.5%", changed it to just display the Rank as an integer.
  What specific changes were made?
Rank was showing as "Rank 5: 98.5%", changed it to just display the Rank as an integer.
Submitter Checklist: 
  - [x] Small scope (1-2 components)
  - [x] Not too many concerns in a single commit
  - [x] Remove extraneous comments (code in comments), print statements, to-dos, console.logs, extra fluff
  - [x] Atomic, descriptive commit messages
  - [x] Consistent formatting

Reviewer Checklist:
  - [x] Small scope (1-2 components)
  - [x] Comments, print statements, to-dos, console.logs, extra fluff were removed
  - [x] Give feedback no matter what conversations happened elsewhere, document here
  - [x] Comment on the line of code itself (blue plus box) in files changed tab