### PR TITLE
Fix/make confidence string

### DIFF
--- a/app/create_db_tables.py
+++ b/app/create_db_tables.py
@@ -16,8 +16,6 @@ def initialize_police_table():
             case_id TEXT,
             city TEXT,
             state TEXT,
-            lat FLOAT,
-            lon FLOAT,
             title TEXT,
             description TEXT,
             tags TEXT,
@@ -36,8 +34,6 @@ def initialize_police_table():
               tags TEXT,
               city TEXT,
               state TEXT,
-              lat FLOAT,
-              lon FLOAT,
               twitterbot_tweet_id TEXT,
               responses TEXT
           );"""

--- a/app/create_db_tables.py
+++ b/app/create_db_tables.py
@@ -20,7 +20,7 @@ def initialize_police_table():
             description TEXT,
             tags TEXT,
             force_rank TEXT,
-            confidence FLOAT
+            confidence TEXT
         );"""
 
     pi_table = """CREATE TABLE IF NOT EXISTS incidents (
@@ -30,7 +30,7 @@ def initialize_police_table():
               user_description TEXT,
               twitter_text TEXT,
               force_rank TEXT,
-              confidence FLOAT,
+              confidence TEXT,
               tags TEXT,
               city TEXT,
               state TEXT,

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -90,8 +90,6 @@ def update_twitter_data():
                 tags = TagMaker(status.full_text, pb_tags).tags()
                 city = None
                 state = None
-                lat = None
-                lon = None
                 twitterbot_tweet_id = None
                 responses = None
                 confidence = rank_confidence
@@ -107,8 +105,6 @@ def update_twitter_data():
                         tags=tags,
                         city=city,
                         state=state,
-                        lat=lat,
-                        lon=lon,
                         twitterbot_tweet_id=twitterbot_tweet_id,
                         responses=responses
                         ))


### PR DESCRIPTION
Naming: feature/descriptive-name

Reviewers: minimum 2 (Chris and/or 2 from Web or DS respectively and not person who submitted PR)

Description: 
  What is the motivation for changes?
Changed confidence format to text and removed latitude and longitude as it is no longer needed.
  What specific changes were made?
Changed confidence format to text on create_db_tables.py and removed latitude and longitude as it is no longer needed on create_db_table.py file and scraper.py
Submitter Checklist: 
  - [x] Small scope (1-2 components)
  - [x] Not too many concerns in a single commit
  - [x] Remove extraneous comments (code in comments), print statements, to-dos, console.logs, extra fluff
  - [x] Atomic, descriptive commit messages
  - [x] Consistent formatting

Reviewer Checklist:
  - [x] Small scope (1-2 components)
  - [x] Comments, print statements, to-dos, console.logs, extra fluff were removed
  - [x] Give feedback no matter what conversations happened elsewhere, document here
  - [x] Comment on the line of code itself (blue plus box) in files changed tab