### PR TITLE
Adds section to readme and fixes typos

### DIFF
--- a/newREADME.md
+++ b/newREADME.md
@@ -27,18 +27,18 @@ There are two notebooks pertaining to the model:
  - `BertModel.ipynb`: trains a BERT instance based on the data given to it from the `training` table in our database 
  - `BertPerformance.ipynb`: used for statistical analysis and to calculate model performance metrics (i.e. binary and multi-classification confusion matrices, accuracy, etc.)
  
-This notebooks can be accessed from your virtual environment once all dependencies are installed in it.  Two additional libraries, Transformers and psycoph2-binary, are both installed after running the first cell within the notebooks.
+These notebooks can be accessed from your virtual environment once all dependencies are installed within it.  Two additional libraries, Transformers and psycoph2-binary, are both installed after running the first cell in the notebooks.
 
 
 </br>  
 
-## Architecture
-
+## DS Architecture
+![Architecture](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/DS%20Flowchart.png?raw=true)
 
 </br>  
 
 ## Old Codebase
-
+Old and currently undeployed code is stored in the `archive` folder of the repo. Some files are stored to show the evolution of the code from previous Lambda cohorts to the current deployed code. Some files are include starter codes that could help provide inspiration for additional features (e.g. Twitter Bot) or functionality that was deprioritized for release. A more in depth description of each of the files is stored in a markdown file in the `archive` directory.
 </br>  
 
 ## Deployed Product
@@ -49,11 +49,6 @@ This notebooks can be accessed from your virtual environment once all dependenci
 
 ## How to access DB from browser
 ![CredentialsMap](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/Credentials_map.png?raw=true)
-
-</br>
-
-## DS Architecture
-![Architecture](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/DS%20Flowchart.png?raw=true)
 
 </br>
 </br>

--- a/newREADME.md
+++ b/newREADME.md
@@ -2,11 +2,14 @@
 
 The Human Rights First Organization is a US-based nonprofit, nonpartisan organization concerned with international human rights. At its forefront are American ideals and universal values. For nearly 40 years HRF has challenged the status quo by highlighting the global struggle for human rights and stepping in to demand reform accountability and justice. The goal of this project is to create a full functioning web application capable of visually demonstrating valid and current incidences of police use of force within the United States. The information will help users, such as journalists and passersby, to formulate their perspectives on current matters. The exemplary user interface immediately captures attention with the clusters of incidence shown by geotagging. 
 
-This project has been worked on by many labs teams over the past 10 months. In the final month of development, Labs Cohort 36 was tasked with finalizing our codebase and architecture to deploy a production-ready app. This included: automating our collection of Twitter data, deploying to AWS Elastic Bean Stalk, connecting our architecture to the backend team's architecture, labeling 5,000 tweets to retrain our BERT model, creating performance metrics for our model, cleaning our codebase, and updating the documentation.
+This project has been worked on by many labs teams over the past 10 months. In the final month of development, Labs Cohort 36 was tasked with finalizing our codebase and architecture to deploy a production-ready app. This included: automating our collection of Twitter data, deploying to AWS Elastic Beanstalk, connecting our architecture to the backend team's architecture, labeling 5,000 tweets to retrain our BERT model, creating performance metrics for our model, cleaning our codebase, and updating the documentation.
 
+</br>  
+
+# Features
 ## Twitter Scraper
 - Automated through the FastAPI framework in ```main.py``` to run every four hours
-- Everytime it runs, will randomly select a search query from a set of phrases (e.g. police, police brutality, police abuse, police violence) to use in the Twitter API search
+- Everytime it runs, will randomly select a search query from a set of phrases (police, police brutality, police abuse, police violence) to use in the Twitter API search
 - Relevant functions for the scraper feature can be found in ```scraper.py```
 
 </br>  
@@ -22,13 +25,14 @@ This project has been worked on by many labs teams over the past 10 months. In t
 
 The BERT model does not currently live in the GitHub repository due to its large file size. When running the app locally, it is best to manually story the `saved_model` file in the `app` directory.
 
-### Model Retraining & Performance Metrics
+</br>  
+
+## Notebooks
 There are two notebooks pertaining to the model:
  - `BertModel.ipynb`: trains a BERT instance based on the data given to it from the `training` table in our database 
  - `BertPerformance.ipynb`: used for statistical analysis and to calculate model performance metrics (i.e. binary and multi-classification confusion matrices, accuracy, etc.)
  
 These notebooks can be accessed from your virtual environment once all dependencies are installed within it.  Two additional libraries, Transformers and psycoph2-binary, are both installed after running the first cell in the notebooks.
-
 
 </br>  
 
@@ -38,7 +42,7 @@ These notebooks can be accessed from your virtual environment once all dependenc
 </br>  
 
 ## Old Codebase
-Old and currently undeployed code is stored in the `archive` folder of the repo. Some files are stored to show the evolution of the code from previous Lambda cohorts to the current deployed code. Some files are include starter codes that could help provide inspiration for additional features (e.g. Twitter Bot) or functionality that was deprioritized for release. A more in depth description of each of the files is stored in a markdown file in the `archive` directory.
+Old and currently undeployed code is stored in the `archive` folder of the repo. Some files are stored to show the evolution of the code from previous Lambda cohorts to the current deployed code. Some files are include starter codes that could help provide inspiration for additional features (e.g. Twitter Bot) or functionality that was deprioritized for initial release. A more in-depth description of each of the files is stored in a markdown file in the `archive` directory.
 </br>  
 
 ## Deployed Product

--- a/newREADME.md
+++ b/newREADME.md
@@ -1,11 +1,65 @@
-# Description
+# Overview
 
 The Human Rights First Organization is a US-based nonprofit, nonpartisan organization concerned with international human rights. At its forefront are American ideals and universal values. For nearly 40 years HRF has challenged the status quo by highlighting the global struggle for human rights and stepping in to demand reform accountability and justice. The goal of this project is to create a full functioning web application capable of visually demonstrating valid and current incidences of police use of force within the United States. The information will help users, such as journalists and passersby, to formulate their perspectives on current matters. The exemplary user interface immediately captures attention with the clusters of incidence shown by geotagging. 
 
-This project has been worked on by many lab teams over the past 10 months. In the final month of development, labs36 was tasked with finalizing our codebase and architecture to deploy a production-ready app. This included: automating our collection of Twitter data, deploying to AWS Bean Stalk, connecting our architecture to the backend team's architecture, labeling 5,000 tweets, retrainining our BERT model, creating performance metrics for our model, cleaning our codebase, and updating the documentation.
+This project has been worked on by many labs teams over the past 10 months. In the final month of development, Labs Cohort 36 was tasked with finalizing our codebase and architecture to deploy a production-ready app. This included: automating our collection of Twitter data, deploying to AWS Elastic Bean Stalk, connecting our architecture to the backend team's architecture, labeling 5,000 tweets to retrain our BERT model, creating performance metrics for our model, cleaning our codebase, and updating the documentation.
+
+## Twitter Scraper
+- Automated through the FastAPI framework in ```main.py``` to run every four hours
+- Everytime it runs, will randomly select a search query from a set of phrases (e.g. police, police brutality, police abuse, police violence) to use in the Twitter API search
+- Relevant functions for the scraper feature can be found in ```scraper.py```
+
+</br>  
+
+## BERT Model
+[BERT is an open-source, pre-trained, natural language processing (NLP) model from Google](https://ai.googleblog.com/2018/11/open-sourcing-bert-state-of-art-pre.html). The role of BERT in our project is to take the tweets collected from our Twitter scraper and predict whether or not the tweet discusses police use-of-force and what type of force they used. BERT uses a 6-rank classification system as follows:
+- Rank 0: No police presence.
+- Rank 1: Police are present, but no force detected.
+- Rank 2: Open-hand: Officers use bodily force to gain control of a situation. Officers may use grabs, holds, and joint locks to restrain an individual.
+- Rank 3: Blunt Force: Officers use less-lethal technologies to gain control of a situation. Baton or projectile may be used to immobilize a combative person for example.
+- Rank 4: Chemical & Electric: Officers use less-lethal technologies to gain control of a situation, such as chemical sprays, projectiles embedded with chemicals, or tasers to restrain an individual.
+- Rank 5: Lethal Force: Officers use lethal weapons (guns, explosives) to gain control of a situation.
+
+The BERT model does not currently live in the GitHub repository due to its large file size. When running the app locally, it is best to manually story the `saved_model` file in the `app` directory.
+
+### Model Retraining & Performance Metrics
+There are two notebooks pertaining to the model:
+ - `BertModel.ipynb`: trains a BERT instance based on the data given to it from the `training` table in our database 
+ - `BertPerformance.ipynb`: used for statistical analysis and to calculate model performance metrics (i.e. binary and multi-classification confusion matrices, accuracy, etc.)
+ 
+This notebooks can be accessed from your virtual environment once all dependencies are installed in it.  Two additional libraries, Transformers and psycoph2-binary, are both installed after running the first cell within the notebooks.
 
 
-# Contributors
+</br>  
+
+## Architecture
+
+
+</br>  
+
+## Old Codebase
+
+</br>  
+
+## Deployed Product
+[Front End Dashboard](https://a.humanrightsfirst.dev/) |
+[Data Science API](http://hrf-bw-labs36-dev.us-east-1.elasticbeanstalk.com/#/)
+
+</br>  
+
+## How to access DB from browser
+![CredentialsMap](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/Credentials_map.png?raw=true)
+
+</br>
+
+## DS Architecture
+![Architecture](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/DS%20Flowchart.png?raw=true)
+
+</br>
+</br>
+</br>
+
+# Labs 36 Contributors
 
 | [Hillary Khan](https://github.com/hillarykhan) | [Marcos Morales](https://github.com/MarcosMorales2011) | [Eric Park](https://github.com/ericyeonpark)
 | :---: | :---: | :---: |
@@ -14,10 +68,13 @@ This project has been worked on by many lab teams over the past 10 months. In th
 |[<img src="https://github.com/favicon.ico" width="15"> ](https://github.com/hillarykhan) | [<img src="https://github.com/favicon.ico" width="15"> ](https://github.com/MarcosMorales2011) | [<img src="https://github.com/favicon.ico" width="15"> ](https://github.com/ericyeonpark) |
 | [ <img src="https://static.licdn.com/sc/h/al2o9zrvru7aqj8e1x2rzsrca" width="15"> ](https://www.linkedin.com/in/hillary-khan/) | [ <img src="https://static.licdn.com/sc/h/al2o9zrvru7aqj8e1x2rzsrca" width="15"> ](https://www.linkedin.com/in/marcos-morales-bb7307181/) | [ <img src="https://static.licdn.com/sc/h/al2o9zrvru7aqj8e1x2rzsrca" width="15"> ](https://www.linkedin.com/in/ericyjpark/) |
 
-<br>          
+</br>
+</br>
+</br>
 
-<br>
-<br>
+# Getting Started
+
+## Dependencies
 
 ![pandas](https://img.shields.io/badge/pandas-1.1.0-blueviolet)
 ![numpy](https://img.shields.io/badge/numpy-1.19.5-yellow)
@@ -35,22 +92,9 @@ This project has been worked on by many lab teams over the past 10 months. In th
 ![fastapi](https://img.shields.io/badge/fastapi-0.60.1-blue)
 ![fastapi-utils](https://img.shields.io/badge/fastapi--utils-0.2.1-informational)
 
+</br>  
 
-# Deployed Product
-[Front End Dashboard](https://a.humanrightsfirst.dev/) |
-[Data Science API](http://hrf-bw-labs36-dev.us-east-1.elasticbeanstalk.com/#/)
-
-
-# How to access DB from browser
-![CredentialsMap](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/Credentials_map.png?raw=true)
-
-# DS Architecture
-![Architecture](https://github.com/Lambda-School-Labs/human-rights-first-police-ds-a/blob/main/DS%20Flowchart.png?raw=true)
-
-
-# Getting Started
-
-### Environment Variables
+## Environment Variables
 
 In order for the app to function correctly, the user must set up their own environment variables. There should be a .env file containing the following:
 
@@ -62,7 +106,9 @@ In order for the app to function correctly, the user must set up their own envir
 	2. Postgres database connection 
 		a. DB_URL
 
-### Installation Instructions and running API locally
+</br>  
+
+## Installation Instructions and running API locally
 
 We used requirement.txt for our dependencies. Here are steps to create a virtual environment and install dependencies from our requirements.txt to run the app locally. Alternative instructions for creating a pipfile with pipenv follow. All code is for Unix/macOS. Here are the [Windows equivalents](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) for creating a virtual environment with pip. 
 


### PR DESCRIPTION
Naming: labs36-readme-edits

Reviewers: minimum 2 (Chris and/or 2 from Web or DS respectively and not person who submitted PR)

Description: 
  What is the motivation for changes?
- To improve readability of the new readme documentation for next cohort/stakeholder
  What specific changes were made?
- Typos were corrected
- Some headers for added for clarification
- Added a brief descriptions for how to use the old codebase and where it was stored
-  Adds an overview of the Twiter scraper and BERT model 

Submitter Checklist: 
  - [X] Small scope (1-2 components)
  - [X] Not too many concerns in a single commit
  - [X] Remove extraneous comments (code in comments), print statements, to-dos, console.logs, extra fluff
  - [X] Atomic, descriptive commit messages
  - [X] Consistent formatting

Reviewer Checklist:
  - [ ] Small scope (1-2 components)
  - [ ] Comments, print statements, to-dos, console.logs, extra fluff were removed
  - [ ] Give feedback no matter what conversations happened elsewhere, document here
  - [ ] Comment on the line of code itself (blue plus box) in files changed tab